### PR TITLE
Headings fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Re-indent a document according to your current indentation settings.
 Useful for converting someone else's style to your own.  Run by selecting
 `Indent Document` under the `Edit` menu, or using the `Ctrl+Alt+I` shortcut.
 
-##Install
+## Install
 
 From the extension manager, search for 'Indentator' and press 'Install'.
 
-##License
+## License
 
 This is free and unencumbered software released into the public domain.
 


### PR DESCRIPTION
a github update made it so you need to add a space in between your pound sign and the text in order for markdown to parse correctly. more info here: https://github.com/github/markup/issues/1013